### PR TITLE
Conserta e melhora lista de contribuidores

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,2 +1,3 @@
-Jéssica Alves de Souza
-Vinícius Gomes de França
+# Contribuidores
+- [Jéssica Alves de Souza](https://github.com/nekojess1)
+- [Vinícius Gomes de França](https://github.com/b1gvini)


### PR DESCRIPTION
No Markdown, quebras de linha no meio do texto normal não fazem nada, a não ser que coloque 2 espaços no final da linha, por isso os 2 nomes estavam mostrando na mesma linha. Mas eu mudei pra uma lista, então não precisa de espaços mais.

Também coloquei links para os perfis do GitHub e coloquei um título.